### PR TITLE
feat(pi): linear-cli pi package manifest (skills-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,15 @@ Example prompts:
 - "Create an issue in the ENG team titled 'Fix login bug'"
 - "Show me issue ENG-123"
 - "Link ENG-123 as blocking ENG-456"
+
+## Pi package
+
+Install as a [pi package](https://pi.dev/packages) to expose the `linear`
+skill to the pi coding agent:
+
+```bash
+pi install git:git@github.com:0xbigboss/linear-cli.git
+```
+
+The skill shells out to the `linear` binary (build via `zig build`); it does
+not install the binary itself.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Install as a [pi package](https://pi.dev/packages) to expose the `linear`
 skill to the pi coding agent:
 
 ```bash
-pi install git:git@github.com:0xbigboss/linear-cli.git
+pi install git:git@github.com:alleneubank/linear-cli.git
 ```
 
 The skill shells out to the `linear` binary (build via `zig build`); it does

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "linear-cli",
+  "version": "0.2.10",
+  "description": "Pi package for @0xbigboss/linear-cli: Linear issue/team/project management via the linear CLI. Exposes the linear skill.",
+  "license": "MIT",
+  "keywords": [
+    "pi-package",
+    "skills",
+    "linear",
+    "issues",
+    "cli"
+  ],
+  "pi": {
+    "skills": [
+      "./skills"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `package.json` `pi` manifest: `pi.skills` → `./skills` (the `linear` skill), `pi-package` keyword.
- README "Pi package" install note.

## Verification
- `pi -e <repo>` exposes the `linear` skill with zero error events.
- No publish performed.